### PR TITLE
Set deps to vvvv packages to 2025.7

### DIFF
--- a/VL.Avalonia.Skia/src/VL.Avalonia.Skia.csproj
+++ b/VL.Avalonia.Skia/src/VL.Avalonia.Skia.csproj
@@ -14,9 +14,9 @@
     <PackageReference Include="Avalonia.Fonts.Inter" Version="11.2.1" />
     <PackageReference Include="Avalonia.Skia" Version="[11.2.1]" />
     <PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
-    <PackageReference Include="VL.Core" Version="2024.6.7" />
-    <PackageReference Include="VL.Core.Skia" Version="2024.6.7" />
-    <PackageReference Include="VL.CoreLib" Version="2024.6.7" />
+    <PackageReference Include="VL.Core" Version="2025.7.0" />
+    <PackageReference Include="VL.Core.Skia" Version="2025.7.0" />
+    <PackageReference Include="VL.CoreLib" Version="2025.7.0" />
   </ItemGroup>
   <!--
 		Reference the Avalonia runtime assemblies (lib/) instead of the reference assemblies (ref/) from nuget packages.

--- a/VL.Avalonia/src/VL.Avalonia.csproj
+++ b/VL.Avalonia/src/VL.Avalonia.csproj
@@ -22,7 +22,7 @@
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="11.2.1" />
     <PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
-    <PackageReference Include="VL.Core" Version="2025.7.0-sbb-0004-ge8e5ef031a" />
+    <PackageReference Include="VL.Core" Version="2025.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This means VL.Avalonia will work only with vvvv gamma 7.0 +