### PR TITLE
fix: forward touch id for multi-touch support

### DIFF
--- a/VL.Avalonia.Skia/src/GammaTopLevelImpl.cs
+++ b/VL.Avalonia.Skia/src/GammaTopLevelImpl.cs
@@ -251,25 +251,23 @@ namespace VL.Avalonia.Skia
             Point position
         )
         {
-            var e = default(RawInputEventArgs);
-
             var eventType = notification.Kind.GetTouchPointerEventType();
 
-            input(
-                e = new RawPointerEventArgs(
-                    TouchDevice,
-                    Timestamp,
-                    InputRoot,
-                    eventType,
-                    position / _scaling,
-                    _inputModifiers
-                )
-            );
+            var e = new RawPointerEventArgs(
+                TouchDevice,
+                Timestamp,
+                InputRoot,
+                eventType,
+                position / _scaling,
+                _inputModifiers
+            )
+            {
+                RawPointerId = notification.Id,
+            };
 
-            if (e != null)
-                return e.Handled;
+            input(e);
 
-            return false;
+            return e.Handled;
         }
 
         public Action<Rect>? Paint { get; set; }


### PR DESCRIPTION
Pass TouchNotification.Id as RawPointerId on RawPointerEventArgs so Avalonia can distinguish simultaneous touch points. Without it all fingers collapsed into a single pointer.